### PR TITLE
[SelfSizingCells] Don't set CZHorizontalSectionAdapterCell.translatesAutoresizingMaskIntoConstraints: Self-sizing cell isn't supported to change `translatesAutoresizingMaskIntoConstraints`.

### DIFF
--- a/Experimental/SelfSizingCell/ReactiveListViewKit/ReactiveListViewKit/TemplateViews/CZHorizontalSectionAdapterCell.swift
+++ b/Experimental/SelfSizingCell/ReactiveListViewKit/ReactiveListViewKit/TemplateViews/CZHorizontalSectionAdapterCell.swift
@@ -36,7 +36,8 @@ public class CZHorizontalSectionAdapterCell: UICollectionViewCell, CZFeedCellVie
   public func setupViewsIfNeeded() {
     guard !hasSetup else {return}
     hasSetup = true
-    translatesAutoresizingMaskIntoConstraints = false
+    // Self-sizing cell isn't supported to change `translatesAutoresizingMaskIntoConstraints`.
+    // translatesAutoresizingMaskIntoConstraints = false
     horizontalSectionAdapterView = CZHorizontalSectionAdapterView(onAction: onAction)
     horizontalSectionAdapterView.overlayOnSuperview(contentView)
   }


### PR DESCRIPTION
…AutoresizingMaskIntoConstraints: Self-sizing cell isn't supported to change `translatesAutoresizingMaskIntoConstraints`.